### PR TITLE
Added support for private jam repos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ The following table details the method by which each tool is able to retrieve pa
 
 -   I've never been on a serious team where no support for `private repositories` would be acceptable. If this is important to you, it seems that your best options are currently *[bower][bower]*, *[component][component]* and *[jam][jam]*.
 -   While *[volo][volo]* doesn't actually claim to have explicit support for `private repositories`, you can achieve the notion of `private repositories` by providing a URL to a single JavaScript source file (github and github:enterprise allow you to link to a `raw` file) or you can specify a URL to a zipball. There are a few more tricks that you can choose from listed [here](https://github.com/volojs/volo/wiki/Library-best-practices).
-
+-   You can setup a private *[jam][jam]* free repo from [garden20](http://garden20.com/market/details/jam). Other details for a private repo can be found [here](https://github.com/caolan/jam/issues/53#issuecomment-10324992).
 
 Speed
 ------------------------------------------------------------


### PR DESCRIPTION
You can setup a jam private repo very easy starting from here:

http://garden20.com/market/details/jam

Which will get one started with a private couchdb repo. Further instructions are here:

https://github.com/caolan/jam/issues/53#issuecomment-10324992
