### PR TITLE
Add npm and browserify

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ The following table details where each tool stores downloaded packages.
  Path           | [bower][bower]      | [component][component] | [jam][jam]     | [volo][volo]                        | [npm][npm] + [browserify][browserify]
 :---------------|:--------------------|:-----------------------|:---------------|:------------------------------------|:---------------
  `default path` | ./components        | ./components           | ./jam          | ./js, ./scripts, ./                 | ./node_modules
- `custom path`  | [.bowerrc][bowerrc] | --out dir              | jam.packageDir | volo.{baseDir,baseUrl}, amd.baseDir | no
+ `custom path`  | [.bowerrc][bowerrc] | --out dir              | jam.packageDir | volo.{baseDir,baseUrl}, amd.baseDir | ✗
 
 
 **NOTES**:


### PR DESCRIPTION
NPM with browserify makes for a browser side package manager.  The diff looks larger than it is as I made a lot of the columns narrower so that (on a wide enough monitor) the tables don't wrap when viewed as plain text.
