### PR TITLE
Remove ✗ symbols from feature tables to make more readable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,11 +248,11 @@ The following table details the responsibilities the given tool takes on.
  Responsibilities        |  [bower][bower] | [component][component] | [jam][jam] |  [volo][volo] | [npm][npm] + [browserify][browserify]
 :------------------------|:----------------|:-----------------------|:-----------|:--------------|:--------------------------------------
  `package management`    |  ✓              | ✓                      | ✓          |  ✓            | ✓ (npm)
- `project bootstrapping` |  ✗              | ✓                      | ✗          |  ✓            | ✓ 
- `project scaffolding`   |  ✗              | ✗                      | ✗          |  ✓            | ✗
- `build automation`      |  ✗              | ✗                      | ✗          |  ✓            | ✗
- `script/module loading` |  ✗              | ✗                      | ✓          |  ✗            | ✗
- `compile/build`         |  ✗              | ✓                      | ✗          |  ✗            | ✓ (browserify)
+ `project bootstrapping` |                 | ✓                      |            |  ✓            | ✓ 
+ `project scaffolding`   |                 |                        |            |  ✓            |  
+ `build automation`      |                 |                        |            |  ✓            |  
+ `script/module loading` |                 |                        | ✓          |               |  
+ `compile/build`         |                 | ✓                      |            |               | ✓ (browserify)
 
 
 **NOTES**:
@@ -305,11 +305,11 @@ The following table details the method by which each tool allows you to specify 
 :-----------------------|:---------------|:-----------------------|:-------------|:--------------------|:--
  `git / github`         | ✓              | ✓                      | ✓ (CLI ONLY) | ✓                   | ✓
  `private repositories` | ✓              | ✓                      | ✓            | ✓ (SEE NOTES BELOW) | ✓
- `local repositories`   | ✓              | ✓                      | ✗            | ✗                   | ✓
- `zip / tarball`        | ✓              | ✗                      | ✓ (CLI ONLY) | ✓ (ZIPBALL ONLY)    | ✓
- `HTTP/HTTPS URL`       | ✓              | ✗                      | ✗            | ✗                   | ✓
- `NPM`                  | ✓              | ✗                      | ✗            | ✗                   | ✓
- `registry`             | ✓              | ✗                      | ✗            | ✗                   | ✓
+ `local repositories`   | ✓              | ✓                      |              |                     | ✓
+ `zip / tarball`        | ✓              |                        | ✓ (CLI ONLY) | ✓ (ZIPBALL ONLY)    | ✓
+ `HTTP/HTTPS URL`       | ✓              |                        |              |                     | ✓
+ `NPM`                  | ✓              |                        |              |                     | ✓
+ `registry`             | ✓              |                        |              |                     | ✓
 
 
 **NOTES**:
@@ -344,10 +344,10 @@ The following table details the JavaScript format each tool expects/handles.
 
  Format               | [bower][bower]      | [component][component] | [jam][jam] | [volo][volo] | [npm][npm] + [browserify][browserify]
 :---------------------|:--------------------|:-----------------------|:-----------|:-------------|:-------------------------------------
- `Global Script`      | ✓                   | ✓ (`--standalone`)     | ✓          | ✓            | ✗
- `AMD`                | ✓ (format agnostic) | ✓ (`--standalone`)     | ✓          | ✓            | ✗
- `CommonJS/NodeJS`    | ✓ (format agnostic) | ✓ (uses CJS style)     | ✗          | ✗            | ✓
- `CommonJS (WRAPPED)` | ✓ (format agnostic) | ✓ (`--standalone`)     | ✓          | ✓            | ✗
+ `Global Script`      | ✓                   | ✓ (`--standalone`)     | ✓          | ✓            |  
+ `AMD`                | ✓ (format agnostic) | ✓ (`--standalone`)     | ✓          | ✓            |  
+ `CommonJS/NodeJS`    | ✓ (format agnostic) | ✓ (uses CJS style)     |            |              | ✓
+ `CommonJS (WRAPPED)` | ✓ (format agnostic) | ✓ (`--standalone`)     | ✓          | ✓            |  
 
 
 **NOTES**:
@@ -394,8 +394,8 @@ The following table details the module/script loader supported by each tool.
 
  Source                 | [bower][bower] | [component][component] | [jam][jam]     | [volo][volo] | [npm][npm] + [browserify][browserify]
 :-----------------------|:---------------|:-----------------------|:---------------|:-------------|:-------------------------------------
- `Bring your own loader`| ✓              | ✗                      |  ✗             | ✓            | ✓ ([can create multiple bundles](https://github.com/substack/node-browserify#multiple-bundles))
- `Includes a Loader`    | ✗              | ✓ (custom require)     |  ✓ (RequireJS) | ✗            | ✓
+ `Bring your own loader`| ✓              |                        |                | ✓            | ✓ ([can create multiple bundles](https://github.com/substack/node-browserify#multiple-bundles))
+ `Includes a Loader`    |                | ✓ (custom require)     |  ✓ (RequireJS) |              | ✓
 
 
 **NOTES**:
@@ -420,8 +420,8 @@ The following table details the the types of source files that can be contained 
  Source       | [bower][bower] | [component][component] | [jam][jam] | [volo][volo] | [npm][npm] + [browserify][browserify]
 :-------------|:---------------|:-----------------------|:-----------|:-------------|:-------------------------------------
  `JavaScript` | ✓              | ✓                      | ✓          | ✓            | ✓
- `HTML`       | ✓              | ✓                      | ✓          | ✗            | ✗
- `CSS`        | ✓              | ✓                      | ✓          | ✗            | ✗
+ `HTML`       | ✓              | ✓                      | ✓          |              |  
+ `CSS`        | ✓              | ✓                      | ✓          |              |  
 
 
 **NOTES**:


### PR DESCRIPTION
I found the bigger feature tables were much more readable without the ✗s. Take it or leave it.
